### PR TITLE
Input queue

### DIFF
--- a/System/Graph/ModuleExecutor.py
+++ b/System/Graph/ModuleExecutor.py
@@ -34,7 +34,7 @@ class ModuleExecutor(object):
         src_seen = []
         dest_seen = []
         count = 1
-        batch_size = 50
+        batch_size = 30
         loading_counter = 0
         for task_input in inputs:
 

--- a/System/Graph/ModuleExecutor.py
+++ b/System/Graph/ModuleExecutor.py
@@ -34,7 +34,7 @@ class ModuleExecutor(object):
         src_seen = []
         dest_seen = []
         count = 1
-        batch_size = 100
+        batch_size = 50
         loading_counter = 0
         for task_input in inputs:
 
@@ -85,6 +85,8 @@ class ModuleExecutor(object):
                 
                 # If loading_counter is batch_size, clear out queue
                 if loading_counter >= batch_size:
+                    logging.debug("Batch size reached on task {0}".format(
+                        self.task_id))
                     # Wait for all processes to finish
                     while len(job_names):
                         self.processor.wait_process(job_names.pop())

--- a/System/Graph/ModuleExecutor.py
+++ b/System/Graph/ModuleExecutor.py
@@ -34,6 +34,8 @@ class ModuleExecutor(object):
         src_seen = []
         dest_seen = []
         count = 1
+        batch_size = 100
+        loading_counter = 0
         for task_input in inputs:
 
             # Don't transfer local files
@@ -74,11 +76,19 @@ class ModuleExecutor(object):
                 self.storage_helper.mv(src_path=src_path,
                                        dest_path=dest_path,
                                        job_name=job_name)
-
+                loading_counter += 1
+                
                 # Add transfer path to list of remote paths that have been transferred to local workspace
                 src_seen.append(src_path)
                 count += 1
                 job_names.append(job_name)
+                
+                # If loading_counter is batch_size, clear out queue
+                if loading_counter >= batch_size:
+                    # Wait for all processes to finish
+                    while len(job_names):
+                        self.processor.wait_process(job_names.pop())
+                    loading_counter = 0
 
             # Update path after transferring to wrk directory and add to list of files in working directory
             task_input.update_path(new_dir=dest_dir, new_filename=dest_filename)

--- a/System/Platform/Processor.py
+++ b/System/Platform/Processor.py
@@ -114,6 +114,7 @@ class Processor(object):
         kwargs["num_retries"] = num_retries
         kwargs["docker_image"] = docker_image
         kwargs["quiet_failure"] = quiet_failure
+        kwargs["close_fds"] = True
 
         # Add process to list of processes
         self.processes[job_name] = Process(cmd, **kwargs)


### PR DESCRIPTION
Develop branch to try to fix OSError: Too many open files that occurred when 1248 files had to be transferred over.

- Add close_fds option when transferring files
- Limit number of files that can be simultaneously transferred
