### PR TITLE
Single cell RNA variant calling

### DIFF
--- a/Modules/Mergers/GATKMergers.py
+++ b/Modules/Mergers/GATKMergers.py
@@ -307,13 +307,18 @@ class CombineGVCF(_GATKBase):
     def define_command(self):
 
         # Obtaining the arguments
-        gvcf_list   = self.get_argument("gvcf")
-        ref         = self.get_argument("ref")
-        L           = self.get_argument("location")
-        XL          = self.get_argument("excluded_location")
-        gvcf_out    = self.get_output("gvcf")
+        gvcf_list    = self.get_argument("gvcf")
+        ref          = self.get_argument("ref")
+        L            = self.get_argument("location")
+        XL           = self.get_argument("excluded_location")
+        gvcf_out     = self.get_output("gvcf")
+        gatk_version = self.get_argument("gatk_version")
 
-        gatk_cmd    = self.get_gatk_command()
+        gatk_version = str(gatk_version).lower().replace("gatk", "")
+        gatk_version = gatk_version.strip()
+        gatk_version = int(gatk_version.split(".")[0])
+
+        gatk_cmd = self.get_gatk_command()
 
         output_file_flag = self.get_output_file_flag()
 
@@ -321,11 +326,16 @@ class CombineGVCF(_GATKBase):
         opts = list()
         opts.append("{0} {1}".format(output_file_flag, gvcf_out))
         opts.append("-R %s" % ref)
-        opts.append("-U ALLOW_SEQ_DICT_INCOMPATIBILITY") # Option that allows dictionary incompatibility
+
+        # Option that allows dictionary incompatibility
+        # Unsafe options are not permitted in GATK4, so only add if using GATK3
+        if gatk_version < 4:
+            opts.append("-U ALLOW_SEQ_DICT_INCOMPATIBILITY")
+
         for gvcf_input in gvcf_list:
             opts.append("-V %s" % gvcf_input)
 
-        # Limit the locations to be processes
+        # Limit the locations to be processed
         if L is not None:
             if isinstance(L, list):
                 for included in L:

--- a/Modules/Splitters/CellBarcodeSplitter.py
+++ b/Modules/Splitters/CellBarcodeSplitter.py
@@ -24,4 +24,4 @@ class CellBarcodeSplitter(Splitter):
 
     def define_command(self):
         # The point of this module is to split the Cloud Conductor graph, not to perform a command, so we do nothing
-        return "sleep 10 !LOG3!"
+        return None

--- a/Modules/Splitters/CellBarcodeSplitter.py
+++ b/Modules/Splitters/CellBarcodeSplitter.py
@@ -1,0 +1,27 @@
+from Modules import Splitter
+
+
+class CellBarcodeSplitter(Splitter):
+
+    def __init__(self, module_id, is_docker=False):
+        super(CellBarcodeSplitter, self).__init__(module_id, is_docker)
+        self.output_keys = ["barcode"]
+
+    def define_input(self):
+        self.add_argument("barcode_list", is_required=True)
+
+        # Set tool specific arguments
+        self.add_argument("nr_cpus",       is_required=True,   default_value=2)
+        self.add_argument("mem",           is_required=True,   default_value=2)
+
+    def define_output(self):
+        # Add a split for each barcode
+        barcode_list = self.get_argument("barcode_list")
+
+        for barcode in barcode_list:
+            self.make_split(split_id=barcode)
+            self.add_output(split_id=barcode, key="barcode", value=barcode, is_path=False)
+
+    def define_command(self):
+        # The point of this module is to split the Cloud Conductor graph, not to perform a command, so we do nothing
+        return "sleep 10 !LOG3!"

--- a/Modules/Tools/GATK.py
+++ b/Modules/Tools/GATK.py
@@ -565,8 +565,8 @@ class SplitNCigarReads(_GATKBase):
 
         if gatk_version < 4:
             opts.append("-rf ReassignOneMappingQuality")
-            opts.append("- RMQF 255")
-            opts.append("- RMQT 60")
+            opts.append("-RMQF 255")
+            opts.append("-RMQT 60")
             opts.append("-U ALLOW_N_CIGAR_READS")
 
         # Generate command for splitting reads

--- a/Modules/Tools/GATK.py
+++ b/Modules/Tools/GATK.py
@@ -400,7 +400,6 @@ class CollectReadCounts(_GATKBase):
         self.add_argument("bam_idx",        is_required=True)
         self.add_argument("nr_cpus",        is_required=True,   default_value=1)
         self.add_argument("mem",            is_required=True,   default_value=2)
-        self.add_argument("interval_list",  is_required=False)
 
     def define_output(self):
         # Declare recoded VCF output filename

--- a/Modules/Tools/GATK.py
+++ b/Modules/Tools/GATK.py
@@ -71,12 +71,13 @@ class HaplotypeCaller(_GATKBase):
 
     def define_input(self):
         self.define_base_args()
-        self.add_argument("bam",                is_required=True)
-        self.add_argument("bam_idx",            is_required=True)
-        self.add_argument("BQSR_report",        is_required=False)
-        self.add_argument("use_bqsr",           is_required=True, default_value=True)
-        self.add_argument("nr_cpus",            is_required=True, default_value=8)
-        self.add_argument("mem",                is_required=True, default_value=48)
+        self.add_argument("bam",                    is_required=True)
+        self.add_argument("bam_idx",                is_required=True)
+        self.add_argument("BQSR_report",            is_required=False)
+        self.add_argument("use_bqsr",               is_required=True, default_value=True)
+        self.add_argument("nr_cpus",                is_required=True, default_value=8)
+        self.add_argument("mem",                    is_required=True, default_value=48)
+        self.add_argument("use_soft_clipped_bases", is_required=True, default_value=True)
 
     def define_output(self):
         # Declare GVCF output filename
@@ -89,49 +90,54 @@ class HaplotypeCaller(_GATKBase):
 
     def define_command(self):
         # Get input arguments
-        bam     = self.get_argument("bam")
-        BQSR    = self.get_argument("BQSR_report")
-        ref     = self.get_argument("ref")
-        L       = self.get_argument("location")
-        XL      = self.get_argument("excluded_location")
-        interval = self.get_argument("interval_list")
-        gvcf    = self.get_output("gvcf")
-        gatk_cmd = self.get_gatk_command()
-        gatk_version = self.get_argument("gatk_version")
-        use_bqsr     = self.get_argument("use_bqsr")
+        bam                    = self.get_argument("bam")
+        BQSR                   = self.get_argument("BQSR_report")
+        ref                    = self.get_argument("ref")
+        L                      = self.get_argument("location")
+        XL                     = self.get_argument("excluded_location")
+        interval               = self.get_argument("interval_list")
+        gvcf                   = self.get_output("gvcf")
+        gatk_cmd               = self.get_gatk_command()
+        gatk_version           = self.get_argument("gatk_version")
+        use_bqsr               = self.get_argument("use_bqsr")
+        use_soft_clipped_bases = self.get_argument("use_soft_clipped_bases")
 
         output_file_flag = self.get_output_file_flag()
 
         # Generating the haplotype caller options
         opts = list()
-        opts.append("-I %s" % bam)
+        opts.append("-I {0}".format(bam))
         opts.append("{0} {1}".format(output_file_flag, gvcf))
-        opts.append("-R %s" % ref)
+        opts.append("-R {0}".format(ref))
         opts.append("-ERC GVCF")
         if BQSR is not None and gatk_version < 4 and use_bqsr:
-            opts.append("-BQSR %s" % BQSR)
+            opts.append("-BQSR {0}".format(BQSR))
 
-        # Limit the locations to be processes
+        # Limit the locations to be processed
         if L is not None:
             if isinstance(L, list):
                 for included in L:
                     if included != "unmapped":
-                        opts.append("-L \"%s\"" % included)
+                        opts.append("-L \"{0}\"".format(included))
             else:
-                opts.append("-L \"%s\"" % L)
+                opts.append("-L \"{0}\"".format(L))
         if XL is not None:
             if isinstance(XL, list):
                 for excluded in XL:
-                    opts.append("-XL \"%s\"" % excluded)
+                    opts.append("-XL \"{0}\"".format(excluded))
             else:
-                opts.append("-XL \"%s\"" % XL)
+                opts.append("-XL \"{0}\"".format(XL))
 
         # Check if an interval list was provided and if yes, place it
         if interval is not None:
             opts.append("-L {0}".format(interval))
 
+        # Add on flag for not using soft clipped bases if defined (used in RNAseq variant calling)
+        if use_soft_clipped_bases == "False":
+            opts.append("--dont-use-soft-clipped-bases")
+
         # Generating command for HaplotypeCaller
-        return "%s HaplotypeCaller %s !LOG3!" % (gatk_cmd, " ".join(opts))
+        return "{0} HaplotypeCaller {1} !LOG3!".format(gatk_cmd, " ".join(opts))
 
 class PrintReads(_GATKBase):
 
@@ -532,6 +538,7 @@ class SplitNCigarReads(_GATKBase):
         bam        = self.get_argument("bam")
         output_bam = self.get_output("bam")
         ref        = self.get_argument("ref")
+        gatk_version = self.get_argument("gatk_version")
 
         # Get JVM options and GATK command
         gatk_cmd = self.get_gatk_command()
@@ -543,6 +550,17 @@ class SplitNCigarReads(_GATKBase):
         opts.append("-R {0}".format(ref))
         opts.append("-I {0}".format(bam))
         opts.append("{0} {1}".format(output_file_flag, output_bam))
+
+        # Determine numeric version of GATK to see if GATK3 options should be added
+        gatk_version = str(gatk_version).lower().replace("gatk","")
+        gatk_version = gatk_version.strip()
+        gatk_version = int(gatk_version.split(".")[0])
+
+        if gatk_version < 4:
+            opts.append("-rf ReassignOneMappingQuality")
+            opts.append("- RMQF 255")
+            opts.append("- RMQT 60")
+            opts.append("-U ALLOW_N_CIGAR_READS")
 
         # Generate command for splitting reads
         return "{0} SplitNCigarReads {1} !LOG3!".format(gatk_cmd, " ".join(opts))

--- a/Modules/Tools/GATK.py
+++ b/Modules/Tools/GATK.py
@@ -513,7 +513,7 @@ class SplitNCigarReads(_GATKBase):
 
     def __init__(self, module_id, is_docker=False):
         super(SplitNCigarReads, self).__init__(module_id, is_docker)
-        self.output_keys  = ["bam", "bam_idx"]
+        self.output_keys  = ["bam"]
 
     def define_input(self):
         self.define_base_args()
@@ -526,30 +526,23 @@ class SplitNCigarReads(_GATKBase):
         # Declare BAM output filename
         bam = self.generate_unique_file_name(extension=".split.bam")
         self.add_output("bam", bam)
-        # Declare BAM index output filename
-        bam_idx = "{0}.bai".format(bam)
-        self.add_output("bam_idx", bam_idx)
 
     def define_command(self):
         # Get arguments needed to generated a SplitNCigarReads command
-        bam     = self.get_argument("bam")
+        bam        = self.get_argument("bam")
         output_bam = self.get_output("bam")
-        nr_cpus = self.get_argument("nr_cpus")
-        ref = self.get_argument("ref")
+        ref        = self.get_argument("ref")
 
+        # Get JVM options and GATK command
         gatk_cmd = self.get_gatk_command()
+
+        output_file_flag = self.get_output_file_flag()
 
         # Generating the options for splitting reads with N in cigar string
         opts = list()
-        opts.append("-nct {}".format(nr_cpus))
-        opts.append("-R {}".format(ref))
-        opts.append("-I {}".format(bam))
-        opts.append("-o {}".format(output_bam))
-        opts.append("-U ALLOW_N_CIGAR_READS")
-        opts.append("-rf ReassignOneMappingQuality")
-        opts.append("-RMQF 255")
-        opts.append("-RMQT 60")
-        opts.append("-fixNDN")
+        opts.append("-R {0}".format(ref))
+        opts.append("-I {0}".format(bam))
+        opts.append("{0} {1}".format(output_file_flag, output_bam))
 
         # Generate command for splitting reads
         return "{0} SplitNCigarReads {1} !LOG3!".format(gatk_cmd, " ".join(opts))

--- a/Modules/Tools/Utils.py
+++ b/Modules/Tools/Utils.py
@@ -546,3 +546,31 @@ class SubsetBamByBarcode(Module):
         cmd = " | ".join(cmds)
 
         return cmd
+
+class ReplaceGVCFSampleName(Module):
+    def __init__(self, module_id, is_docker=False):
+        super(ReplaceGVCFSampleName, self).__init__(module_id, is_docker)
+        self.output_keys = ["gvcf"]
+
+    def define_input(self):
+        self.add_argument("barcode",      is_required=True)
+        self.add_argument("gvcf",         is_required=True)
+        self.add_argument("sample_name",  is_required=True)
+        self.add_argument("nr_cpus",      is_required=True, default_value=1)
+        self.add_argument("mem",          is_required=True, default_value=1)
+
+    def define_output(self):
+        gvcf = self.generate_unique_file_name(extension=".g.vcf")
+        self.add_output("gvcf", gvcf)
+
+    def define_command(self):
+        sample_name = self.get_argument("sample_name")
+        barcode     = self.get_argument("barcode")
+        gvcf_in     = self.get_argument("gvcf")
+        gvcf_out    = self.get_output("gvcf")
+
+        # The one line with the sample name at the end of the line ($) is the header line #CHROM ... sample_name,
+        # so we replace that sample name with the barcode
+        cmd = 'sed "s/{0}$/{1}/g" {2} > {3}'.format(sample_name, barcode, gvcf_in, gvcf_out)
+
+        return cmd


### PR DESCRIPTION
New modules and updates to GATK module to support variant calling in single cell RNAseq.

Modules:
- CellBarcodeSplitter (new): split up pipeline graph by cellular barcodes given in input
- SplitNCigarReads (GATK) (new): add submodule used in RNAseq variant calling best practices
- GetCellBarcodes (Utils) (new): process input cellular barcodes
- SubsetBamByBarcodes (Utils) (new): select only the reads from a CellRanger BAM that contain the given cellular barcode
- ReplaceGVCFSampleName (Utils) (new): replace single cell sample name with cell barcode in GVCFs
- CombineGVCF (GATKMergers) (modified): only use unsafe options in GATK3, as they are not permitted in GATK4
- HaplotypeCaller (GATK) (modified): add flag to  used in RNAseq variant calling best practices