### PR TITLE
Use __file__  instead of sys.path[0] to obtain the CC directory.

### DIFF
--- a/CloudConductor
+++ b/CloudConductor
@@ -150,7 +150,7 @@ def configure_logging(verbosity):
 def configure_import_paths():
 
     # Get the directory of the executable
-    exec_dir = sys.path[0]
+    exec_dir = os.path.dirname(__file__)
 
     # Add the modules paths to the python path
     sys.path.insert(1, os.path.join(exec_dir, "Modules/Tools/"))
@@ -173,7 +173,7 @@ def get_git_version():
     # Return the git commit at runtime
 
     # Get the directory of the executable
-    exec_dir = sys.path[0]
+    exec_dir = os.path.dirname(__file__)
 
     # Run command to determine id of current commit
     cmd = "cd '{0}' ; git log -1 --pretty=%H".format(exec_dir)

--- a/Config/Parsers/BaseParser.py
+++ b/Config/Parsers/BaseParser.py
@@ -16,7 +16,14 @@ class BaseParser(object, metaclass=abc.ABCMeta):
         if os.path.isabs(config_spec_file):
             self.config_spec_file = config_spec_file
         else:
-            self.config_spec_file = os.path.join(sys.path[0], config_spec_file)
+            self.config_spec_file = os.path.join(
+                os.path.dirname(
+                    os.path.dirname(
+                        os.path.dirname(__file__)
+                    )
+                ),
+                config_spec_file
+            )
 
         # Check to make sure config file and config spec file actually exist
         self.__check_files()


### PR DESCRIPTION
sys.path[0] works fine if we execute CC as a command line tool. However, sys.path[0] may not be the CC root directory if the CC code is imported to other python script/module/packages. 

If we run tests with python unittest. The tests will failed if the file containing the test is not located at the CC root directory.

We can obtain the root directory through "\_\_file_\_\" attribute to avoid this problem.