### PR TITLE
Update Task.get_task_string() to output correct module and submodule …

### DIFF
--- a/System/Graph/Task.py
+++ b/System/Graph/Task.py
@@ -200,7 +200,10 @@ class Task(object):
     def get_task_string(self, input_from=None):
         # Get the module names
         to_ret = "[%s]\n" % self.__task_id
-        to_ret +="\tmodule\t= %s\n" % self.module.__class__.__name__
+        to_ret +="\tmodule\t= %s\n" % self.__module_name
+
+        if self.__submodule_name:
+            to_ret += "\tsubmodule\t= %s\n" % self.__submodule_name
 
         if len(self.__final_output_keys) == 1:
             to_ret += "\tfinal_output\t= %s\n" % self.__final_output_keys[0]


### PR DESCRIPTION
Task.get_task_string()  does not output the correct string.
1. Does not have submodule in the output config
2. It uses submodule name as module name if the tool is a submodule.

This method is probably not updated when we introduce the idea of submodule.
