### PR TITLE
UMI 

### DIFF
--- a/Modules/Module.py
+++ b/Modules/Module.py
@@ -78,7 +78,7 @@ class Module(object, metaclass=abc.ABCMeta):
 
     def add_output(self, key, value, is_path=True, **kwargs):
         if key in self.output:
-            logging.error("In module %s, the output key '%s' is defined multiple time!" % (self.module_id, key))
+            logging.error("In module %s, the output key '%s' is defined multiple times!" % (self.module_id, key))
             raise RuntimeError("Output key '%s' has been defined multiple times!" % key)
 
         if is_path and not isinstance(value, GAPFile) and value is not None:

--- a/Modules/Tools/GATK.py
+++ b/Modules/Tools/GATK.py
@@ -1571,7 +1571,9 @@ class MergeBamAlignment(_GATKBase):
     def define_output(self):
         # Declare BAM output filename
         bam = self.generate_unique_file_name(extension=".umi.bam")
-        bam_idx = "{0}.bai".format(bam)
+        # MergeBamAlignment creates a file.bam and a file.bai output. We
+        # reflect that naming convention here.
+        bam_idx = "{0}.bai".format(bam[:-4])
         self.add_output("bam", bam)
         self.add_output("bam_idx", bam_idx)
 

--- a/Modules/Tools/GATK.py
+++ b/Modules/Tools/GATK.py
@@ -1557,7 +1557,7 @@ class MergeBamAlignment(_GATKBase):
 
     def __init__(self, module_id, is_docker=False):
         super(MergeBamAlignment, self).__init__(module_id, is_docker)
-        self.output_keys  = ["bam"]
+        self.output_keys  = ["bam", "bam_idx"]
 
     def define_input(self):
         self.define_base_args()

--- a/Modules/Tools/GATK.py
+++ b/Modules/Tools/GATK.py
@@ -1564,7 +1564,6 @@ class MergeBamAlignment(_GATKBase):
         self.add_argument("bam",           is_required=True)
         self.add_argument("bam_idx",       is_required=True)
         self.add_argument("umi_bam",       is_required=True)
-        self.add_argument("umi_bam_idx",   is_required=True)
         self.add_argument("ref",           is_required=True, is_resource=True)
         self.add_argument("nr_cpus",       is_required=True, default_value=4)
         self.add_argument("mem",           is_required=True, default_value="nr_cpus * 2.5")

--- a/Modules/Tools/GATK.py
+++ b/Modules/Tools/GATK.py
@@ -1553,8 +1553,43 @@ class CollectSequencingArtifactMetrics(_GATKBase):
         return "{0} !LOG3!".format(cmd)
 
 
-class MergeBamAlignment(_GATKBase):
+class CollectReadCounts(_GATKBase):
 
+    def __init__(self, module_id, is_docker=False):
+        super(CollectReadCounts, self).__init__(module_id, is_docker)
+        self.output_keys = ["read_count_out"]
+
+    def define_input(self):
+        self.define_base_args()
+        self.add_argument("bam",            is_required=True)
+        self.add_argument("bam_idx",        is_required=True)
+        self.add_argument("nr_cpus",        is_required=True,   default_value=1)
+        self.add_argument("mem",            is_required=True,   default_value=2)
+
+    def define_output(self):
+        # Declare recoded VCF output filename
+        read_count_out = self.generate_unique_file_name(extension=".read_count.txt")
+        self.add_output("read_count_out", read_count_out)
+
+    def define_command(self):
+        # Get input arguments
+        bam             = self.get_argument("bam")
+        gatk_cmd        = self.get_gatk_command()
+        read_count_out  = self.get_output("read_count_out")
+        interval_list   = self.get_argument("interval_list")
+
+        output_file_flag = self.get_output_file_flag()
+
+        cmd = "{0} CollectReadCounts -I {1} {3} {2} --format TSV -DF MappingQualityReadFilter ".format(gatk_cmd, bam, read_count_out, output_file_flag)
+
+        if interval_list is not None:
+            cmd = "{0} -L {1} --interval-merging-rule OVERLAPPING_ONLY".format(cmd, interval_list)
+
+        return "{0} !LOG3!".format(cmd)
+
+
+
+class MergeBamAlignment(_GATKBase):
     def __init__(self, module_id, is_docker=False):
         super(MergeBamAlignment, self).__init__(module_id, is_docker)
         self.output_keys  = ["bam", "bam_idx"]

--- a/Modules/Tools/GATK.py
+++ b/Modules/Tools/GATK.py
@@ -1551,3 +1551,52 @@ class CollectSequencingArtifactMetrics(_GATKBase):
         cmd = "{0} -I {1} -R {2} {3} {4}".format(cmd, bam, ref, output_file_flag, artifact_bias_matrics)
 
         return "{0} !LOG3!".format(cmd)
+
+
+class MergeBamAlignment(_GATKBase):
+
+    def __init__(self, module_id, is_docker=False):
+        super(MergeBamAlignment, self).__init__(module_id, is_docker)
+        self.output_keys  = ["bam"]
+
+    def define_input(self):
+        self.define_base_args()
+        self.add_argument("bam",           is_required=True)
+        self.add_argument("bam_idx",       is_required=True)
+        self.add_argument("umi_bam",       is_required=True)
+        self.add_argument("umi_bam_idx",   is_required=True)
+        self.add_argument("ref",           is_required=True, is_resource=True)
+        self.add_argument("nr_cpus",       is_required=True, default_value=4)
+        self.add_argument("mem",           is_required=True, default_value="nr_cpus * 2.5")
+
+    def define_output(self):
+        # Declare BAM output filename
+        bam = self.generate_unique_file_name(extension=".umi.bam")
+        bam_idx = "{0}.bai".format(bam)
+        self.add_output("bam", bam)
+        self.add_output("bam_idx", bam_idx)
+
+    def define_command(self):
+        # Get arguments needed to generate a MergeBamAlignment command
+        bam        = self.get_argument("bam")
+        umi_bam    = self.get_argument("umi_bam")
+        output_bam = self.get_output("bam")
+        ref        = self.get_argument("ref")
+
+        # Get JVM options and GATK command
+        gatk_cmd = self.get_gatk_command()
+
+        # Generating the options for merging aligned BAM with UMI BAM
+        opts = list()
+        opts.append("-ALIGNED {0}".format(bam))
+        opts.append("-UNMAPPED {0}".format(umi_bam))
+        opts.append("-O {0}".format(output_bam))
+        opts.append("-R {0}".format(ref))
+        opts.append("--EXPECTED_ORIENTATIONS FR")
+        opts.append("--MAX_GAPS -1")
+        opts.append("--SORT_ORDER coordinate")
+        opts.append("--CREATE_INDEX true")
+        opts.append("--ALIGNER_PROPER_PAIR_FLAGS false")
+
+        # Generate command for splitting reads
+        return "{0} MergeBamAlignment {1} !LOG3!".format(gatk_cmd, " ".join(opts))

--- a/Modules/Tools/Picard.py
+++ b/Modules/Tools/Picard.py
@@ -9,12 +9,13 @@ class MarkDuplicates(Module):
         self.output_keys            = ["bam", "MD_report", "bam_sorted"]
 
     def define_input(self):
-        self.add_argument("bam",        is_required=True)
-        self.add_argument("bam_idx",    is_required=True)
-        self.add_argument("is_aligned", is_required=True, default_value=True)
-        self.add_argument("picard",     is_required=True, is_resource=True)
-        self.add_argument("nr_cpus",    is_required=True, default_value=8)
-        self.add_argument("mem",        is_required=True, default_value=61)
+        self.add_argument("bam",         is_required=True)
+        self.add_argument("bam_idx",     is_required=True)
+        self.add_argument("is_aligned",  is_required=True,  default_value=True)
+        self.add_argument("picard",      is_required=True,  is_resource=True)
+        self.add_argument("nr_cpus",     is_required=True,  default_value=8)
+        self.add_argument("mem",         is_required=True,  default_value=61)
+        self.add_argument("barcode_tag", is_required=False, default_value=None)
 
         # Require java if not being run on docker
         if not self.is_docker:
@@ -44,6 +45,7 @@ class MarkDuplicates(Module):
         is_aligned  = self.get_argument("is_aligned")
         mem         = self.get_argument("mem")
         picard      = self.get_argument("picard")
+        barcode_tag = self.get_argument("barcode_tag")
 
         # Get output filenames
         output_bam  = self.get_output("bam")
@@ -72,6 +74,9 @@ class MarkDuplicates(Module):
         mark_dup_opts.append("ASSUME_SORTED=TRUE")
         mark_dup_opts.append("REMOVE_DUPLICATES=FALSE")
         mark_dup_opts.append("VALIDATION_STRINGENCY=LENIENT")
+
+        if barcode_tag is not None:
+            mark_dup_opts.append("BARCODE_TAG={0}".format(barcode_tag))
 
         # Generating command for marking duplicates
         cmd = "{0} MarkDuplicates {1} !LOG3!".format(basecmd, " ".join(mark_dup_opts))

--- a/Modules/Tools/RenameKeys.py
+++ b/Modules/Tools/RenameKeys.py
@@ -2,7 +2,7 @@ import os
 from Modules import Module
 
 class RenameRNA(Module):
-    def __init__(self, module_id, is_docker = False):
+    def __init__(self, module_id, is_docker=False):
         super(RenameRNA, self).__init__(module_id, is_docker)
         self.output_keys    = ["rna_bam", "rna_bam_idx"]
 
@@ -24,3 +24,24 @@ class RenameRNA(Module):
 
         cmd = "samtools index {} !LOG3!".format(rna_bam)
         return cmd
+
+
+class RenameUMI(Module):
+    def __init__(self, module_id, is_docker=False):
+        super(RenameUMI, self).__init__(module_id, is_docker)
+        self.output_keys = ["umi_bam"]
+
+    def define_input(self):
+        self.add_argument("bam", is_required=True)
+        self.add_argument("nr_cpus", default_value=1)
+        self.add_argument("mem", default_value=5)
+
+    def define_output(self):
+        # get bam file names from the sample sheet
+        bam = self.get_argument("bam")
+        self.add_output("umi_bam", bam)
+
+    def define_command(self):
+        cmd = "echo 'Wrapping input bam as umi_bam key...' !LOG3!"
+        return cmd
+

--- a/Modules/Tools/Samtools.py
+++ b/Modules/Tools/Samtools.py
@@ -309,3 +309,34 @@ class Fastq(Module):
 
         # Generate command for obtaining the FASTQ reads
         return "{0} fastq {1} {2} !LOG3!".format(samtools, " ".join(opts), bam)
+
+
+class AddReplaceRG(Module):
+    def __init__(self, module_id, is_docker = False):
+        super(AddReplaceRG, self).__init__(module_id, is_docker)
+        self.output_keys = ["bam"]
+
+    def define_input(self):
+        self.add_argument("bam",        is_required=True)
+        self.add_argument("samtools",   is_required=True, is_resource=True)
+        self.add_argument("nr_cpus",    is_required=True, default_value=8)
+        self.add_argument("mem",        is_required=True, default_value=20)
+        self.add_argument("read_group", is_required=True)
+
+    def define_output(self):
+        bam = self.generate_unique_file_name(".bam")
+        self.add_output("bam", bam, is_path=True)
+
+    def define_command(self):
+        # Define command for running samtools addreplacerg to add a read group
+        # to the BAM header
+        nr_cpus        = self.get_argument("nr_cpus")
+        in_bam         = self.get_argument("bam")
+        out_bam        = self.get_output("bam")
+        samtools       = self.get_argument("samtools")
+        read_group     = self.get_argument("read_group")
+
+        # Generating indexing command
+        cmd = '{0} addreplacerg -@ {1} -r "{2}" -o {3} {4} !LOG3!'.format(
+            samtools, nr_cpus, read_group, out_bam, in_bam)
+        return cmd

--- a/Modules/Tools/Utils.py
+++ b/Modules/Tools/Utils.py
@@ -920,7 +920,7 @@ class GetReadNames(Module):
             cmds.append("{0} intersect -a {1} -b {2} -split".format(bedtools, bam, bed))
 
         # Convert BAM to SAM
-        cmds.append("{0} view".format(samtools))
+        cmds.append("{0} view {1}".format(samtools, bam))
 
         # get the read names
         cmds.append("cut -f 1 > {0} !LOG2!".format(read_names))

--- a/Modules/Tools/Utils.py
+++ b/Modules/Tools/Utils.py
@@ -769,6 +769,7 @@ class ReplaceGVCFSampleName(Module):
 
         return cmd
 
+
 class GetDemuxFASTQ(Module):
 
     def __init__(self, module_id, is_docker=False):
@@ -914,8 +915,9 @@ class GetReadNames(Module):
         # Generating the commands that will be piped together
         cmds = list()
 
-        # intresect BAM with a given BED
-        cmds.append("{0} intersect -a {1} -b {2} -split".format(bedtools, bam, bed))
+        # Intersect BAM with a given BED
+        if bed is not None:
+            cmds.append("{0} intersect -a {1} -b {2} -split".format(bedtools, bam, bed))
 
         # Convert BAM to SAM
         cmds.append("{0} view".format(samtools))


### PR DESCRIPTION
New modules:
- Samtools:AddReplaceRG module for adding a read group to a BAM
- GATK:MergeBamAlignment, with new key "umi_bam" to denote an unaligned BAM with UMI tags
- RecodeKeys:RecodeUMI to change a bam file key to a umi_bam key before passing in to MergeBamAlignment

Modified modules:
- Picard MarkDuplicates: add barcode_tag option to support UMIs
- Utils:GetReadNames has bed file optional and a bug fixed
- RenameRNA:RenameRNA now changed to RenameKeys:RenameRNA

