### PR TITLE
GATK Diagnose targets module

### DIFF
--- a/Modules/Mergers/GATKMergers.py
+++ b/Modules/Mergers/GATKMergers.py
@@ -497,7 +497,7 @@ class DiagnoseTargets(_GATKBase):
 
     def __init__(self, module_id, is_docker=False):
         super(DiagnoseTargets, self).__init__(module_id, is_docker)
-        self.output_keys = ["vcf", "vcf_idx"]
+        self.output_keys = ["vcf", "vcf_idx", "missing_intervals"]
 
     def define_input(self):
         self.define_base_args()


### PR DESCRIPTION
Create a DiagnoseTargets merger module. This module takes in a list of BAM files and a capture panel. Its output is a VCF with one line per capture panel interval, with the depth and alignment characteristics of that interval across the input BAM files.