### PR TITLE
Rename keys

### DIFF
--- a/Modules/Tools/Bedtools.py
+++ b/Modules/Tools/Bedtools.py
@@ -25,7 +25,6 @@ class BamToFastq(Module):
         r1 					= self.get_output("R1")
         r2 					= self.get_output("R2")
 
-#Veronica's change
         cmd = "samtools index {0} !LOG3!;".format(bam)
         cmd += "samtools sort -n {0} -o {1} !LOG3!;".format(bam, sorted_bam)
         cmd += "bedtools bamtofastq -i {0} -fq {1} -fq2 {2} !LOG3!".format(sorted_bam, r1, r2)

--- a/Modules/Tools/RenameKeys.py
+++ b/Modules/Tools/RenameKeys.py
@@ -177,7 +177,7 @@ class RenameLongInsertBamToBam(Module):
 
     def define_output(self):
         # get bam file names from the sample sheet
-        bam = self.get_argument("long_insert_bam")
+        long_insert_bam = self.get_argument("long_insert_bam")
         self.add_output("bam", long_insert_bam)
 
     def define_command(self):

--- a/Modules/Tools/RenameKeys.py
+++ b/Modules/Tools/RenameKeys.py
@@ -107,3 +107,62 @@ class RenameRnaBamToBam(Module):
         return cmd
 
 
+
+class RenameTranscriptomeBamToBam(Module):
+    def __init__(self, module_id, is_docker=False):
+        super(RenameTranscriptomeBamToBam, self).__init__(module_id, is_docker)
+        self.output_keys = ["bam"]
+
+    def define_input(self):
+        self.add_argument("transcriptome_mapped_bam", is_required=True)
+        self.add_argument("nr_cpus", default_value=1)
+        self.add_argument("mem", default_value=5)
+
+    def define_output(self):
+        # get bam file names from the sample sheet
+        bam = self.get_argument("transcriptome_mapped_bam")
+        self.add_output("bam", bam)
+
+    def define_command(self):
+        cmd = "echo 'Wrapping input transcriptome_mapped_bam as bam key...' !LOG3!"
+        return cmd
+
+
+class RenameBamToSplicedTxBam(Module):
+    def __init__(self, module_id, is_docker=False):
+        super(RenameBamToSplicedTxBam, self).__init__(module_id, is_docker)
+        self.output_keys = ["spliced_rna_transcriptome_bam"]
+
+    def define_input(self):
+        self.add_argument("bam", is_required=True)
+        self.add_argument("nr_cpus", default_value=1)
+        self.add_argument("mem", default_value=5)
+
+    def define_output(self):
+        # get bam file names from the sample sheet
+        bam = self.get_argument("bam")
+        self.add_output("spliced_rna_transcriptome_bam", bam)
+
+    def define_command(self):
+        cmd = "echo 'Wrapping input bam as spliced_rna_transcriptome_bam key...' !LOG3!"
+        return cmd
+
+class RenameBamToShortInsertTxBam(Module):
+    def __init__(self, module_id, is_docker=False):
+        super(RenameBamToShortInsertTxBam, self).__init__(module_id, is_docker)
+        self.output_keys = ["short_insert_rna_transcriptome_bam"]
+
+    def define_input(self):
+        self.add_argument("bam", is_required=True)
+        self.add_argument("nr_cpus", default_value=1)
+        self.add_argument("mem", default_value=5)
+
+    def define_output(self):
+        # get bam file names from the sample sheet
+        bam = self.get_argument("bam")
+        self.add_output("short_insert_rna_transcriptome_bam", bam)
+
+    def define_command(self):
+        cmd = "echo 'Wrapping input bam as short_insert_rna_transcriptome_bam key...' !LOG3!"
+        return cmd
+

--- a/Modules/Tools/RenameKeys.py
+++ b/Modules/Tools/RenameKeys.py
@@ -107,7 +107,6 @@ class RenameRnaBamToBam(Module):
         return cmd
 
 
-
 class RenameTranscriptomeBamToBam(Module):
     def __init__(self, module_id, is_docker=False):
         super(RenameTranscriptomeBamToBam, self).__init__(module_id, is_docker)
@@ -164,5 +163,44 @@ class RenameBamToShortInsertTxBam(Module):
 
     def define_command(self):
         cmd = "echo 'Wrapping input bam as short_insert_rna_transcriptome_bam key...' !LOG3!"
+        return cmd
+
+class RenameLongInsertBamToBam(Module):
+    def __init__(self, module_id, is_docker=False):
+        super(RenameLongInsertBamToBam, self).__init__(module_id, is_docker)
+        self.output_keys = ["bam"]
+
+    def define_input(self):
+        self.add_argument("long_insert_bam", is_required=True)
+        self.add_argument("nr_cpus", default_value=1)
+        self.add_argument("mem", default_value=5)
+
+    def define_output(self):
+        # get bam file names from the sample sheet
+        bam = self.get_argument("long_insert_bam")
+        self.add_output("bam", long_insert_bam)
+
+    def define_command(self):
+        cmd = "echo 'Wrapping input long_insert_bam as bam key...' !LOG3!"
+        return cmd
+
+
+class RenameBamToLongInsertTxBam(Module):
+    def __init__(self, module_id, is_docker=False):
+        super(RenameBamToLongInsertTxBam, self).__init__(module_id, is_docker)
+        self.output_keys = ["long_insert_rna_transcriptome_bam"]
+
+    def define_input(self):
+        self.add_argument("bam", is_required=True)
+        self.add_argument("nr_cpus", default_value=1)
+        self.add_argument("mem", default_value=5)
+
+    def define_output(self):
+        # get bam file names from the sample sheet
+        bam = self.get_argument("bam")
+        self.add_output("long_insert_rna_transcriptome_bam", bam)
+
+    def define_command(self):
+        cmd = "echo 'Wrapping input bam as long_insert_rna_transcriptome_bam key...' !LOG3!"
         return cmd
 

--- a/Modules/Tools/RenameKeys.py
+++ b/Modules/Tools/RenameKeys.py
@@ -127,9 +127,9 @@ class RenameTranscriptomeBamToBam(Module):
         return cmd
 
 
-class RenameBamToSplicedTxBam(Module):
+class RenameBamToSplicedTxRNABam(Module):
     def __init__(self, module_id, is_docker=False):
-        super(RenameBamToSplicedTxBam, self).__init__(module_id, is_docker)
+        super(RenameBamToSplicedTxRNABam, self).__init__(module_id, is_docker)
         self.output_keys = ["spliced_rna_transcriptome_bam"]
 
     def define_input(self):
@@ -145,6 +145,26 @@ class RenameBamToSplicedTxBam(Module):
     def define_command(self):
         cmd = "echo 'Wrapping input bam as spliced_rna_transcriptome_bam key...' !LOG3!"
         return cmd
+
+class RenameBamToSplicedTxDNABam(Module):
+    def __init__(self, module_id, is_docker=False):
+        super(RenameBamToSplicedTxDNABam, self).__init__(module_id, is_docker)
+        self.output_keys = ["spliced_dna_transcriptome_bam"]
+
+    def define_input(self):
+        self.add_argument("bam", is_required=True)
+        self.add_argument("nr_cpus", default_value=1)
+        self.add_argument("mem", default_value=5)
+
+    def define_output(self):
+        # get bam file names from the sample sheet
+        bam = self.get_argument("bam")
+        self.add_output("spliced_dna_transcriptome_bam", bam)
+
+    def define_command(self):
+        cmd = "echo 'Wrapping input bam as spliced_dna_transcriptome_bam key...' !LOG3!"
+        return cmd
+
 
 class RenameBamToShortInsertTxBam(Module):
     def __init__(self, module_id, is_docker=False):
@@ -164,6 +184,7 @@ class RenameBamToShortInsertTxBam(Module):
     def define_command(self):
         cmd = "echo 'Wrapping input bam as short_insert_rna_transcriptome_bam key...' !LOG3!"
         return cmd
+
 
 class RenameLongInsertBamToBam(Module):
     def __init__(self, module_id, is_docker=False):
@@ -185,9 +206,9 @@ class RenameLongInsertBamToBam(Module):
         return cmd
 
 
-class RenameBamToLongInsertTxBam(Module):
+class RenameBamToLongInsertTxRNABam(Module):
     def __init__(self, module_id, is_docker=False):
-        super(RenameBamToLongInsertTxBam, self).__init__(module_id, is_docker)
+        super(RenameBamToLongInsertTxRNABam, self).__init__(module_id, is_docker)
         self.output_keys = ["long_insert_rna_transcriptome_bam"]
 
     def define_input(self):
@@ -203,4 +224,25 @@ class RenameBamToLongInsertTxBam(Module):
     def define_command(self):
         cmd = "echo 'Wrapping input bam as long_insert_rna_transcriptome_bam key...' !LOG3!"
         return cmd
+
+
+class RenameBamToLongInsertTxDNABam(Module):
+    def __init__(self, module_id, is_docker=False):
+        super(RenameBamToLongInsertTxDNABam, self).__init__(module_id, is_docker)
+        self.output_keys = ["long_insert_dna_transcriptome_bam"]
+
+    def define_input(self):
+        self.add_argument("bam", is_required=True)
+        self.add_argument("nr_cpus", default_value=1)
+        self.add_argument("mem", default_value=5)
+
+    def define_output(self):
+        # get bam file names from the sample sheet
+        bam = self.get_argument("bam")
+        self.add_output("long_insert_dna_transcriptome_bam", bam)
+
+    def define_command(self):
+        cmd = "echo 'Wrapping input bam as long_insert_dna_transcriptome_bam key...' !LOG3!"
+        return cmd
+
 

--- a/Modules/Tools/RenameKeys.py
+++ b/Modules/Tools/RenameKeys.py
@@ -1,6 +1,67 @@
 import os
 from Modules import Module
 
+
+class RenameUMI(Module):
+    def __init__(self, module_id, is_docker=False):
+        super(RenameUMI, self).__init__(module_id, is_docker)
+        self.output_keys = ["umi_bam"]
+
+    def define_input(self):
+        self.add_argument("bam", is_required=True)
+        self.add_argument("nr_cpus", default_value=1)
+        self.add_argument("mem", default_value=5)
+
+    def define_output(self):
+        # get bam file names from the sample sheet
+        bam = self.get_argument("bam")
+        self.add_output("umi_bam", bam)
+
+    def define_command(self):
+        cmd = "echo 'Wrapping input bam as umi_bam key...' !LOG3!"
+        return cmd
+
+
+class RenameTranscriptomeBamToBam(Module):
+    def __init__(self, module_id, is_docker=False):
+        super(RenameTranscriptomeBamToBam, self).__init__(module_id, is_docker)
+        self.output_keys = ["bam"]
+
+    def define_input(self):
+        self.add_argument("transcriptome_mapped_bam", is_required=True)
+        self.add_argument("nr_cpus", default_value=1)
+        self.add_argument("mem", default_value=5)
+
+    def define_output(self):
+        # get bam file names from the sample sheet
+        bam = self.get_argument("transcriptome_mapped_bam")
+        self.add_output("bam", bam)
+
+    def define_command(self):
+        cmd = "echo 'Wrapping input transcriptome_mapped_bam as bam key...' !LOG3!"
+        return cmd
+
+
+class RenameBamToTranscriptomeBam(Module):
+    def __init__(self, module_id, is_docker=False):
+        super(RenameBamToTranscriptomeBam, self).__init__(module_id, is_docker)
+        self.output_keys = ["transcriptome_mapped_bam"]
+
+    def define_input(self):
+        self.add_argument("bam", is_required=True)
+        self.add_argument("nr_cpus", default_value=1)
+        self.add_argument("mem", default_value=5)
+
+    def define_output(self):
+        # get bam file names from the sample sheet
+        bam = self.get_argument("bam")
+        self.add_output("transcriptome_mapped_bam", bam)
+
+    def define_command(self):
+        cmd = "echo 'Wrapping input bam as transcriptome_mapped_bam key...' !LOG3!"
+        return cmd
+
+
 class RenameRNA(Module):
     def __init__(self, module_id, is_docker=False):
         super(RenameRNA, self).__init__(module_id, is_docker)
@@ -26,63 +87,6 @@ class RenameRNA(Module):
         return cmd
 
 
-class RenameUMI(Module):
-    def __init__(self, module_id, is_docker=False):
-        super(RenameUMI, self).__init__(module_id, is_docker)
-        self.output_keys = ["umi_bam"]
-
-    def define_input(self):
-        self.add_argument("bam", is_required=True)
-        self.add_argument("nr_cpus", default_value=1)
-        self.add_argument("mem", default_value=5)
-
-    def define_output(self):
-        # get bam file names from the sample sheet
-        bam = self.get_argument("bam")
-        self.add_output("umi_bam", bam)
-
-    def define_command(self):
-        cmd = "echo 'Wrapping input bam as umi_bam key...' !LOG3!"
-        return cmd
-
-class RenameTranscriptomeBamToBam(Module):
-    def __init__(self, module_id, is_docker=False):
-        super(RenameTranscriptomeBamToBam, self).__init__(module_id, is_docker)
-        self.output_keys = ["bam"]
-
-    def define_input(self):
-        self.add_argument("transcriptome_mapped_bam", is_required=True)
-        self.add_argument("nr_cpus", default_value=1)
-        self.add_argument("mem", default_value=5)
-
-    def define_output(self):
-        # get bam file names from the sample sheet
-        bam = self.get_argument("transcriptome_mapped_bam")
-        self.add_output("bam", bam)
-
-    def define_command(self):
-        cmd = "echo 'Wrapping input transcriptome_mapped_bam as bam key...' !LOG3!"
-        return cmd
-
-class RenameBamToTranscriptomeBam(Module):
-    def __init__(self, module_id, is_docker=False):
-        super(RenameBamToTranscriptomeBam, self).__init__(module_id, is_docker)
-        self.output_keys = ["transcriptome_mapped_bam"]
-
-    def define_input(self):
-        self.add_argument("bam", is_required=True)
-        self.add_argument("nr_cpus", default_value=1)
-        self.add_argument("mem", default_value=5)
-
-    def define_output(self):
-        # get bam file names from the sample sheet
-        bam = self.get_argument("bam")
-        self.add_output("transcriptome_mapped_bam", bam)
-
-    def define_command(self):
-        cmd = "echo 'Wrapping input bam as transcriptome_mapped_bam key...' !LOG3!"
-        return cmd
-
 class RenameRnaBamToBam(Module):
     def __init__(self, module_id, is_docker=False):
         super(RenameRnaBamToBam, self).__init__(module_id, is_docker)
@@ -102,21 +106,4 @@ class RenameRnaBamToBam(Module):
         cmd = "echo 'Wrapping input rna_bam as bam key...' !LOG3!"
         return cmd
 
-class RenameSortedBamToBam(Module):
-    def __init__(self, module_id, is_docker=False):
-        super(RenameSortedBamToBam, self).__init__(module_id, is_docker)
-        self.output_keys = ["bam"]
 
-    def define_input(self):
-        self.add_argument("sorted_bam", is_required=True)
-        self.add_argument("nr_cpus", default_value=1)
-        self.add_argument("mem", default_value=5)
-
-    def define_output(self):
-        # get bam file names from the sample sheet
-        bam = self.get_argument("sorted_bam")
-        self.add_output("bam", bam)
-
-    def define_command(self):
-        cmd = "echo 'Wrapping input sorted_bam as bam key...' !LOG3!"
-        return cmd

--- a/Modules/Tools/Samtools.py
+++ b/Modules/Tools/Samtools.py
@@ -8,7 +8,7 @@ class Index(Module):
 
     def define_input(self):
         self.add_argument("bam",        is_required=True)
-        self.add_argument("sorted_transcriptome_bam")
+        self.add_argument("transcriptome_mapped_bam")
         self.add_argument("samtools",   is_required=True, is_resource=True)
         self.add_argument("nr_cpus",    is_required=True, default_value=3)
         self.add_argument("mem",        is_required=True, default_value=10)
@@ -28,7 +28,7 @@ class Index(Module):
         self.add_output("bam_idx", bams_idx, is_path=True)
 
         # logic for the STAR generated Transcriptome BAM
-        sorted_transcriptome_bams = self.get_argument("sorted_transcriptome_bam")
+        sorted_transcriptome_bams = self.get_argument("transcriptome_mapped_bam")
 
         if sorted_transcriptome_bams:
             # Check if the input is a list
@@ -45,7 +45,7 @@ class Index(Module):
     def define_command(self):
         # Define command for running samtools index from a platform
         bam                         = self.get_argument("bam")
-        sorted_transcriptome_bam    = self.get_argument("sorted_transcriptome_bam")
+        sorted_transcriptome_bam    = self.get_argument("transcriptome_mapped_bam")
         samtools                    = self.get_argument("samtools")
 
         bam_idx                     = self.get_output("bam_idx")
@@ -86,7 +86,7 @@ class Index(Module):
 class Sort(Module):
     def __init__(self, module_id, is_docker = False):
         super(Sort, self).__init__(module_id, is_docker)
-        self.output_keys = ["sorted_bam","sorted_transcriptome_bam"]
+        self.output_keys = ["bam", "transcriptome_mapped_bam"]
 
     def define_input(self):
         self.add_argument("bam")
@@ -114,7 +114,7 @@ class Sort(Module):
                 sorted_bams = bams + ".sorted.bam"
 
             # Add new bams as output
-            self.add_output("sorted_bam", sorted_bams, is_path=True)
+            self.add_output("bam", sorted_bams, is_path=True)
 
         if transcriptome_bams:
             # Check if the input is a list
@@ -125,7 +125,7 @@ class Sort(Module):
                 sorted_transcriptome_bams = transcriptome_bams + ".sorted.bam"
 
             # Add new bams as output
-            self.add_output("sorted_transcriptome_bam", sorted_transcriptome_bams, is_path=True)
+            self.add_output("transcriptome_mapped_bam", sorted_transcriptome_bams, is_path=True)
 
 
     def define_command(self):
@@ -141,7 +141,7 @@ class Sort(Module):
 
         if bam:
 
-            sorted_bam = self.get_output("sorted_bam")
+            sorted_bam = self.get_output("bam")
 
             if isinstance(bam, list):
                 for b_in, b_out in zip(bam, sorted_bam):
@@ -152,7 +152,7 @@ class Sort(Module):
 
         if transcriptome_mapped_bam:
 
-            sorted_transcriptome_bam        = self.get_output("sorted_transcriptome_bam")
+            sorted_transcriptome_bam        = self.get_output("transcriptome_mapped_bam")
 
             if transcriptome_mapped_bam:
                 if isinstance(transcriptome_mapped_bam, list):
@@ -181,7 +181,7 @@ class Stats(Module):
     def define_input(self):
         self.add_argument("bam")
         self.add_argument("bam_idx")
-        self.add_argument("sorted_transcriptome_bam")
+        self.add_argument("transcriptome_mapped_bam")
         self.add_argument("transcriptome_bam_idx")
         self.add_argument("samtools",                   is_required=True, is_resource=True)
         self.add_argument("remove_dups",                default_value=True)
@@ -197,7 +197,7 @@ class Stats(Module):
     def define_command(self):
         # Define command for running samtools stats from a platform
         bam                         = self.get_argument("bam")
-        transcriptome_mapped_bam    = self.get_argument("sorted_transcriptome_bam")
+        transcriptome_mapped_bam    = self.get_argument("transcriptome_mapped_bam")
         samtools                    = self.get_argument("samtools")
         remove_dups                 = self.get_argument("remove_dups")
         remove_overlaps             = self.get_argument("remove_overlaps")


### PR DESCRIPTION
Add support for outputting split up transcriptome BAMs.
- Add rename key modules to support key renaming to and from `bam` key
- Replaced all instances of `sorted_transcriptome_bam` with `transcriptome_mapped_bam` and replaced `sorted_bam` with `bam`